### PR TITLE
Do not die if last require failed

### DIFF
--- a/lib/Class/Refresh.pm
+++ b/lib/Class/Refresh.pm
@@ -187,11 +187,20 @@ sub load_module {
     my ($mod) = @_;
     $mod = $class->_file_to_mod($mod);
 
+    my $file = $class->_mod_to_file($mod);
+    my $last_require_failed = exists $INC{$file} && !defined $INC{$file};
+
     try {
         Class::Load::load_class($mod);
     }
     catch {
-        die $_;
+        if ($last_require_failed) {
+                # This file failed to load previously.
+                # Presumably that error has already been caught, so that's fine
+        }
+        else {
+                die $_;
+        }
     }
     finally {
         $class->_update_cache_for($mod);

--- a/t/basic.t
+++ b/t/basic.t
@@ -2,8 +2,10 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Fatal;
 use lib 't/lib';
 use Test::Class::Refresh;
+use Try::Tiny;
 
 use Class::Refresh;
 
@@ -36,5 +38,15 @@ is($Foo::BAZ, 30, "third package global exists");
 is(eval '$Foo::FOO', 10, "package global exists with new value");
 ok(!defined(eval '$Foo::BAR'), "other package global doesn't exist");
 is(eval '$Foo::BAZ', 30, "third package global exists");
+
+try { require UseFake } catch { "We expect this to fail, that's alright and happens sometimes" };
+Class::Refresh->refresh;
+ok(exists $INC{'UseFake.pm'}, "Failed package \$INC value exists");
+ok(!defined $INC{'UseFake.pm'}, "Failed package \$INC value is not defined after failed load");
+
+# Now do the same thing to validate that there's no error in repopulating %CACHE
+isnt(exception{ Class::Refresh->refresh }, "Second refresh is not an error");
+ok(exists $INC{'UseFake.pm'}, "Failed package \$INC value exists: second attempt");
+ok(!defined $INC{'UseFake.pm'}, "Failed package \$INC value is not defined after failed load: second attempt");
 
 done_testing;

--- a/t/basic.t
+++ b/t/basic.t
@@ -39,14 +39,14 @@ is(eval '$Foo::FOO', 10, "package global exists with new value");
 ok(!defined(eval '$Foo::BAR'), "other package global doesn't exist");
 is(eval '$Foo::BAZ', 30, "third package global exists");
 
-try { require UseFake } catch { "We expect this to fail, that's alright and happens sometimes" };
+try { require Bar } catch { "We expect this to fail, that's alright and happens sometimes" };
 Class::Refresh->refresh;
-ok(exists $INC{'UseFake.pm'}, "Failed package \$INC value exists");
-ok(!defined $INC{'UseFake.pm'}, "Failed package \$INC value is not defined after failed load");
+ok(exists $INC{'Bar.pm'}, "Failed package \$INC value exists");
+ok(!defined $INC{'Bar.pm'}, "Failed package \$INC value is not defined after failed load");
 
 # Now do the same thing to validate that there's no error in repopulating %CACHE
 isnt(exception{ Class::Refresh->refresh }, "Second refresh is not an error");
-ok(exists $INC{'UseFake.pm'}, "Failed package \$INC value exists: second attempt");
-ok(!defined $INC{'UseFake.pm'}, "Failed package \$INC value is not defined after failed load: second attempt");
+ok(exists $INC{'Bar.pm'}, "Failed package \$INC value exists: second attempt");
+ok(!defined $INC{'Bar.pm'}, "Failed package \$INC value is not defined after failed load: second attempt");
 
 done_testing;

--- a/t/data/basic/after/Bar.pm
+++ b/t/data/basic/after/Bar.pm
@@ -1,0 +1,5 @@
+package Bar;
+
+use Bar::Fake;
+
+1;

--- a/t/data/basic/after/UseFake.pm
+++ b/t/data/basic/after/UseFake.pm
@@ -1,5 +1,0 @@
-package RequiresFake;
-
-use Fake;
-
-1;

--- a/t/data/basic/after/UseFake.pm
+++ b/t/data/basic/after/UseFake.pm
@@ -1,0 +1,5 @@
+package RequiresFake;
+
+use Fake;
+
+1;


### PR DESCRIPTION
There is currently a bug in Class::Refresh.

Suppose a module has been required, but that require failed:

```
foreach my $module (qw( ModA ModB ModC )) {
    if (eval "require $module; 1") {  # now using this module
        last;
    }
}
```

This is acceptable enough perl.  `$INC{'ModA.pm'}` may be `undef` to indicate that the search failed.

Class::Refresh should not die when it finds a module in `%INC` which is `undef` and it fails to load, because presumably that error was already handled by whatever code tried to load it.  Otherwise, there would have been an exception and we wouldn't be trying to `Class::Refresh->refresh` at all!

Let me know if you have any questions or want any clarification!
